### PR TITLE
Boat Frame Blocks for each wood type

### DIFF
--- a/src/main/java/com/hyperdash/firmaciv/common/block/AngledWatercraftFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/AngledWatercraftFrameBlock.java
@@ -1,11 +1,8 @@
 package com.hyperdash.firmaciv.common.block;
 
 import com.hyperdash.firmaciv.common.blockentity.WatercraftFrameBlockEntity;
-import com.hyperdash.firmaciv.common.item.FirmacivItems;
 import com.hyperdash.firmaciv.util.FirmacivTags;
-import net.dries007.tfc.util.Helpers;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -14,37 +11,26 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.properties.Half;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
-import net.minecraft.world.level.block.state.properties.StairsShape;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.registries.RegistryObject;
 
-import javax.annotation.Nullable;
-
-public class AngledWatercraftFrameBlock extends SquaredAngleBlock implements EntityBlock {
+public class AngledWatercraftFrameBlock extends SquaredAngleBlock {
 
     public static final IntegerProperty FRAME_PROCESSED = FirmacivBlockStateProperties.FRAME_PROCESSED_8;
 
     public AngledWatercraftFrameBlock(final BlockState blockState, final BlockBehaviour.Properties properties) {
         super(blockState, properties);
-        this.registerDefaultState(
-                this.getStateDefinition().any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
-                        .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, false)
-                        .setValue(FRAME_PROCESSED, 0));
     }
 
     @Override
     public void onRemove(final BlockState blockState, final Level level, final BlockPos blockPos,
             final BlockState newState, final boolean isMoving) {
+
         if (level.getBlockEntity(blockPos) instanceof WatercraftFrameBlockEntity frameBlockEntity) {
-            if (!Helpers.isBlock(blockState, newState.getBlock())) {
+            if (!blockState.is(newState.getBlock())) {
                 frameBlockEntity.ejectContents();
             }
         }
@@ -52,13 +38,6 @@ public class AngledWatercraftFrameBlock extends SquaredAngleBlock implements Ent
         if (blockState.hasBlockEntity() && (!blockState.is(newState.getBlock()) || !newState.hasBlockEntity())) {
             level.removeBlockEntity(blockPos);
         }
-
-        super.onRemove(blockState, level, blockPos, newState, isMoving);
-    }
-
-    @Override
-    protected void createBlockStateDefinition(final StateDefinition.Builder<Block, BlockState> builder) {
-        super.createBlockStateDefinition(builder.add(FRAME_PROCESSED));
     }
 
     @Override
@@ -67,88 +46,32 @@ public class AngledWatercraftFrameBlock extends SquaredAngleBlock implements Ent
         // Don't do logic on client side
         if (level.isClientSide()) return InteractionResult.SUCCESS;
 
-        if (hand != InteractionHand.MAIN_HAND) return InteractionResult.FAIL;
-
-        final WatercraftFrameBlockEntity frameBlockEntity;
-        {
-            final BlockEntity blockEntity = level.getBlockEntity(blockPos);
-            if (!(blockEntity instanceof WatercraftFrameBlockEntity)) {
-                return InteractionResult.FAIL;
-            } else frameBlockEntity = (WatercraftFrameBlockEntity) blockEntity;
-        }
-
         final ItemStack heldStack = player.getItemInHand(hand);
-        final int processState = blockState.getValue(FRAME_PROCESSED);
-
-        // Try extract
-        if (heldStack.isEmpty()) {
-            // Extract an item
-            if (4 >= processState) {
-                ItemHandlerHelper.giveItemToPlayer(player, frameBlockEntity.extractPlanks(1));
-            } else {
-                ItemHandlerHelper.giveItemToPlayer(player, frameBlockEntity.extractBolts(1));
-            }
-
-            // Update the state
-            if (0 < processState) {
-                level.setBlock(blockPos, blockState.setValue(FRAME_PROCESSED, processState - 1), 10);
-            }
-
-            return InteractionResult.SUCCESS;
-        }
 
         // Should we do plank stuff
-        if (heldStack.is(FirmacivTags.Items.PLANKS)) {
-            // We must replace ourselves with the correct wood version
-            if (0 == processState) {
-                for (final RegistryObject<Block> registryObject : FirmacivBlocks.WOOD_WATERCRAFT_FRAMES.values()) {
-                    if (!(registryObject.get() instanceof WoodenAngledWatercraftFrameBlock woodenFrameBlock)) continue;
+        if (!heldStack.is(FirmacivTags.Items.PLANKS)) return InteractionResult.SUCCESS;
 
-                    // Try find
-                    if (!heldStack.is(woodenFrameBlock.getUnderlyingPlank().asItem())) continue;
+        // We must replace ourselves with the correct wood version
+        for (final RegistryObject<Block> registryObject : FirmacivBlocks.WOOD_WATERCRAFT_FRAMES.values()) {
+            if (!(registryObject.get() instanceof WoodenAngledWatercraftFrameBlock woodenFrameBlock)) continue;
 
-                    final BlockState newBlockState = woodenFrameBlock.defaultBlockState().setValue(FRAME_PROCESSED, 1)
-                            .setValue(SHAPE, blockState.getValue(SHAPE)).setValue(FACING, blockState.getValue(FACING));
+            // Must find the right block variant for this item
+            if (!heldStack.is(woodenFrameBlock.getUnderlyingPlank().asItem())) continue;
 
-                    frameBlockEntity.insertPlanks(heldStack.split(1));
-                    level.setBlock(blockPos, newBlockState, 10);
-                    level.playSound(null, blockPos, SoundEvents.WOOD_PLACE, SoundSource.BLOCKS, 1.5F,
-                            level.getRandom().nextFloat() * 0.1F + 0.9F);
-                    return InteractionResult.SUCCESS;
-                }
-                return InteractionResult.FAIL;
-            }
+            final BlockState newBlockState = woodenFrameBlock.defaultBlockState().setValue(FRAME_PROCESSED, 1)
+                    .setValue(SHAPE, blockState.getValue(SHAPE)).setValue(FACING, blockState.getValue(FACING));
 
-            // Must be [0,4)
-            if (4 > processState) {
+            level.setBlock(blockPos, newBlockState, 10);
+
+            if (level.getBlockEntity(blockPos) instanceof WatercraftFrameBlockEntity frameBlockEntity) {
                 frameBlockEntity.insertPlanks(heldStack.split(1));
-                level.setBlock(blockPos, blockState.cycle(FRAME_PROCESSED), 10);
-                level.playSound(null, blockPos, SoundEvents.WOOD_PLACE, SoundSource.BLOCKS, 1.5F,
-                        level.getRandom().nextFloat() * 0.1F + 0.9F);
-                return InteractionResult.SUCCESS;
             }
-            return InteractionResult.SUCCESS;
-        }
 
-        // Should we do bolt stuff
-        if (heldStack.is(FirmacivItems.COPPER_BOLT.get())) {
-            // Must be [4,8)
-            if (4 <= processState && processState < 8) {
-                frameBlockEntity.insertBolts(heldStack.split(1));
-                level.setBlock(blockPos, blockState.cycle(FRAME_PROCESSED), 10);
-                level.playSound(null, blockPos, SoundEvents.METAL_PLACE, SoundSource.BLOCKS, 1.5F,
-                        level.getRandom().nextFloat() * 0.1F + 0.9F);
-                return InteractionResult.SUCCESS;
-            }
+            level.playSound(null, blockPos, SoundEvents.WOOD_PLACE, SoundSource.BLOCKS, 1.5F,
+                    level.getRandom().nextFloat() * 0.1F + 0.9F);
             return InteractionResult.SUCCESS;
         }
 
         return InteractionResult.SUCCESS;
-    }
-
-    @Nullable
-    @Override
-    public BlockEntity newBlockEntity(final BlockPos blockPos, final BlockState blockState) {
-        return new WatercraftFrameBlockEntity(blockPos, blockState);
     }
 }

--- a/src/main/java/com/hyperdash/firmaciv/common/block/AngledWatercraftFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/AngledWatercraftFrameBlock.java
@@ -26,21 +26,6 @@ public class AngledWatercraftFrameBlock extends SquaredAngleBlock {
     }
 
     @Override
-    public void onRemove(final BlockState blockState, final Level level, final BlockPos blockPos,
-            final BlockState newState, final boolean isMoving) {
-
-        if (level.getBlockEntity(blockPos) instanceof WatercraftFrameBlockEntity frameBlockEntity) {
-            if (!blockState.is(newState.getBlock())) {
-                frameBlockEntity.ejectContents();
-            }
-        }
-
-        if (blockState.hasBlockEntity() && (!blockState.is(newState.getBlock()) || !newState.hasBlockEntity())) {
-            level.removeBlockEntity(blockPos);
-        }
-    }
-
-    @Override
     public InteractionResult use(final BlockState blockState, final Level level, final BlockPos blockPos,
             final Player player, final InteractionHand hand, final BlockHitResult hitResult) {
         // Don't do logic on client side

--- a/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
@@ -5,6 +5,7 @@ import com.hyperdash.firmaciv.common.entity.BoatVariant;
 import com.hyperdash.firmaciv.common.item.FirmacivItems;
 import net.dries007.tfc.client.TFCSounds;
 import net.dries007.tfc.common.blocks.TFCBlocks;
+import net.dries007.tfc.common.blocks.wood.Wood;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.Metal;
 import net.minecraft.world.item.BlockItem;
@@ -56,6 +57,12 @@ public class FirmacivBlocks {
     public static final RegistryObject<Block> WATERCRAFT_FRAME_ANGLED = registerBlockWithItem("watercraft_frame_angled",
             () -> new AngledWatercraftFrameBlock(Blocks.ACACIA_STAIRS.defaultBlockState(),
                     BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS).noOcclusion()));
+
+    public static final Map<Wood, RegistryObject<Block>> WOOD_WATERCRAFT_FRAMES = Helpers.mapOfKeys(Wood.class, wood ->
+            registerBlockWithoutItem("wood/" + wood.getSerializedName() + "/watercraft_frame_angled",
+                    () -> new WoodenAngledWatercraftFrameBlock(wood,
+                            wood.getBlock(Wood.BlockType.STAIRS).get().defaultBlockState(),
+                            BlockBehaviour.Properties.copy(WATERCRAFT_FRAME_ANGLED.get()))));
 
     public static final RegistryObject<Block> OARLOCK = registerBlockWithItem("oarlock",
             () -> new OarlockBlock(BlockBehaviour.Properties.copy(

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenAngledWatercraftFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenAngledWatercraftFrameBlock.java
@@ -1,21 +1,117 @@
 package com.hyperdash.firmaciv.common.block;
 
+import com.hyperdash.firmaciv.common.blockentity.WatercraftFrameBlockEntity;
+import com.hyperdash.firmaciv.common.item.FirmacivItems;
+import com.hyperdash.firmaciv.util.FirmacivTags;
 import net.dries007.tfc.common.blocks.wood.Wood;
 import net.dries007.tfc.util.registry.RegistryWood;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.Half;
+import net.minecraft.world.level.block.state.properties.StairsShape;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.items.ItemHandlerHelper;
 
-public class WoodenAngledWatercraftFrameBlock extends AngledWatercraftFrameBlock {
+import javax.annotation.Nullable;
+
+public class WoodenAngledWatercraftFrameBlock extends AngledWatercraftFrameBlock implements EntityBlock {
 
     public final RegistryWood wood;
 
     public WoodenAngledWatercraftFrameBlock(final RegistryWood wood, final BlockState blockState,
             final Properties properties) {
         super(blockState, properties);
+        this.registerDefaultState(
+                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
+                        .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, false)
+                        .setValue(FRAME_PROCESSED, 0));
         this.wood = wood;
+    }
+
+    @Override
+    protected void createBlockStateDefinition(final StateDefinition.Builder<Block, BlockState> builder) {
+        super.createBlockStateDefinition(builder.add(FRAME_PROCESSED));
+    }
+
+    @Override
+    public InteractionResult use(final BlockState blockState, final Level level, final BlockPos blockPos,
+            final Player player, final InteractionHand hand, final BlockHitResult hitResult) {
+        // Don't do logic on client side
+        if (level.isClientSide()) return InteractionResult.SUCCESS;
+
+        if (hand != InteractionHand.MAIN_HAND) return InteractionResult.FAIL;
+
+        // Quit early if we don't have the right BlockEntity
+        if (!(level.getBlockEntity(blockPos) instanceof WatercraftFrameBlockEntity frameBlockEntity)) {
+            return InteractionResult.FAIL;
+        }
+
+        final ItemStack heldStack = player.getItemInHand(hand);
+
+        final int processState = blockState.getValue(FRAME_PROCESSED);
+
+        // Try extract
+        if (heldStack.isEmpty()) {
+            // Extract an item
+            if (4 >= processState) {
+                ItemHandlerHelper.giveItemToPlayer(player, frameBlockEntity.extractPlanks(1));
+            } else {
+                ItemHandlerHelper.giveItemToPlayer(player, frameBlockEntity.extractBolts(1));
+            }
+
+            // Set ourselves back to our base
+            if (1 == processState) {
+                final BlockState newState = FirmacivBlocks.WATERCRAFT_FRAME_ANGLED.get().defaultBlockState()
+                        .setValue(SHAPE, blockState.getValue(SHAPE)).setValue(FACING, blockState.getValue(FACING));
+                level.setBlock(blockPos, newState, 10);
+                return InteractionResult.SUCCESS;
+            }
+
+            level.setBlock(blockPos, blockState.setValue(FRAME_PROCESSED, processState - 1), 10);
+
+            return InteractionResult.SUCCESS;
+        }
+
+        // Should we do plank stuff
+        if (heldStack.is(FirmacivTags.Items.PLANKS)) {
+            // Must be [0,4)
+            if (4 > processState) {
+                frameBlockEntity.insertPlanks(heldStack.split(1));
+                level.setBlock(blockPos, blockState.cycle(FRAME_PROCESSED), 10);
+                level.playSound(null, blockPos, SoundEvents.WOOD_PLACE, SoundSource.BLOCKS, 1.5F,
+                        level.getRandom().nextFloat() * 0.1F + 0.9F);
+                return InteractionResult.SUCCESS;
+            }
+            return InteractionResult.SUCCESS;
+        }
+
+        // Should we do bolt stuff
+        if (heldStack.is(FirmacivItems.COPPER_BOLT.get())) {
+            // Must be [4,8)
+            if (4 <= processState && processState < 8) {
+                frameBlockEntity.insertBolts(heldStack.split(1));
+                level.setBlock(blockPos, blockState.cycle(FRAME_PROCESSED), 10);
+                level.playSound(null, blockPos, SoundEvents.METAL_PLACE, SoundSource.BLOCKS, 1.5F,
+                        level.getRandom().nextFloat() * 0.1F + 0.9F);
+                return InteractionResult.SUCCESS;
+            }
+            return InteractionResult.SUCCESS;
+        }
+
+        return InteractionResult.SUCCESS;
     }
 
     @Override
@@ -28,5 +124,11 @@ public class WoodenAngledWatercraftFrameBlock extends AngledWatercraftFrameBlock
 
     public Block getUnderlyingPlank() {
         return wood.getBlock(Wood.BlockType.PLANKS).get();
+    }
+
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(final BlockPos blockPos, final BlockState blockState) {
+        return new WatercraftFrameBlockEntity(blockPos, blockState);
     }
 }

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenAngledWatercraftFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenAngledWatercraftFrameBlock.java
@@ -1,0 +1,32 @@
+package com.hyperdash.firmaciv.common.block;
+
+import net.dries007.tfc.common.blocks.wood.Wood;
+import net.dries007.tfc.util.registry.RegistryWood;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class WoodenAngledWatercraftFrameBlock extends AngledWatercraftFrameBlock {
+
+    public final RegistryWood wood;
+
+    public WoodenAngledWatercraftFrameBlock(final RegistryWood wood, final BlockState blockState,
+            final Properties properties) {
+        super(blockState, properties);
+        this.wood = wood;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public ItemStack getCloneItemStack(final BlockGetter blockGetter, final BlockPos blockPos,
+            final BlockState blockState) {
+        // We don't exist as an item so pass it the base version instead
+        return FirmacivBlocks.WATERCRAFT_FRAME_ANGLED.get().getCloneItemStack(blockGetter, blockPos, blockState);
+    }
+
+    public Block getUnderlyingPlank() {
+        return wood.getBlock(Wood.BlockType.PLANKS).get();
+    }
+}

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenAngledWatercraftFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenAngledWatercraftFrameBlock.java
@@ -42,6 +42,20 @@ public class WoodenAngledWatercraftFrameBlock extends AngledWatercraftFrameBlock
     }
 
     @Override
+    public void onRemove(final BlockState blockState, final Level level, final BlockPos blockPos,
+            final BlockState newState, final boolean isMoving) {
+        if (level.getBlockEntity(blockPos) instanceof WatercraftFrameBlockEntity frameBlockEntity) {
+            if (!blockState.is(newState.getBlock())) {
+                frameBlockEntity.ejectContents();
+            }
+        }
+
+        if (blockState.hasBlockEntity() && (!blockState.is(newState.getBlock()) || !newState.hasBlockEntity())) {
+            level.removeBlockEntity(blockPos);
+        }
+    }
+
+    @Override
     protected void createBlockStateDefinition(final StateDefinition.Builder<Block, BlockState> builder) {
         super.createBlockStateDefinition(builder.add(FRAME_PROCESSED));
     }

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenAngledWatercraftFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenAngledWatercraftFrameBlock.java
@@ -27,7 +27,9 @@ import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
 
-public class WoodenAngledWatercraftFrameBlock extends AngledWatercraftFrameBlock implements EntityBlock {
+import static com.hyperdash.firmaciv.common.block.AngledWatercraftFrameBlock.FRAME_PROCESSED;
+
+public class WoodenAngledWatercraftFrameBlock extends SquaredAngleBlock implements EntityBlock {
 
     public final RegistryWood wood;
 
@@ -37,6 +39,7 @@ public class WoodenAngledWatercraftFrameBlock extends AngledWatercraftFrameBlock
         this.registerDefaultState(
                 this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
                         .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, false)
+                        // TODO state 0 is no longer actually used as no progress is represented as a separate block
                         .setValue(FRAME_PROCESSED, 0));
         this.wood = wood;
     }


### PR DESCRIPTION
Assets aren't included however a follow-up PR for data generation will include them.
We are currently directly calling our map of WoodenAngledWatercraftFrameBlock, we should come up with a good way for other addons to add themselves to some sort of list so they don't need to do anything gross