### PR TITLE
Frame block cleanup. Primarily our wooden frames are fully functional

### DIFF
--- a/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
@@ -12,14 +12,15 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.registries.RegistryObject;
 
+import java.util.function.Supplier;
+
 public class AngledBoatFrameBlock extends SquaredAngleBlock {
 
-    public AngledBoatFrameBlock(final BlockState blockState, final BlockBehaviour.Properties properties) {
+    public AngledBoatFrameBlock(final Supplier<BlockState> blockState, final Properties properties) {
         super(blockState, properties);
     }
 

--- a/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
@@ -1,5 +1,6 @@
 package com.hyperdash.firmaciv.common.block;
 
+import com.hyperdash.firmaciv.Firmaciv;
 import com.hyperdash.firmaciv.common.blockentity.WatercraftFrameBlockEntity;
 import com.hyperdash.firmaciv.util.FirmacivTags;
 import net.minecraft.core.BlockPos;
@@ -56,6 +57,9 @@ public class AngledBoatFrameBlock extends SquaredAngleBlock {
                     level.getRandom().nextFloat() * 0.1F + 0.9F);
             return InteractionResult.SUCCESS;
         }
+
+        Firmaciv.LOGGER.error("Couldn't find a frame for the item {} even though it's contained in {}",
+                heldStack.getItem(), FirmacivTags.Items.PLANKS);
 
         return InteractionResult.SUCCESS;
     }

--- a/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
@@ -14,13 +14,10 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.registries.RegistryObject;
 
 public class AngledBoatFrameBlock extends SquaredAngleBlock {
-
-    public static final IntegerProperty FRAME_PROCESSED = FirmacivBlockStateProperties.FRAME_PROCESSED_8;
 
     public AngledBoatFrameBlock(final BlockState blockState, final BlockBehaviour.Properties properties) {
         super(blockState, properties);
@@ -44,7 +41,7 @@ public class AngledBoatFrameBlock extends SquaredAngleBlock {
             // Must find the right block variant for this item
             if (!heldStack.is(woodenFrameBlock.getUnderlyingPlank().asItem())) continue;
 
-            final BlockState newBlockState = woodenFrameBlock.defaultBlockState().setValue(FRAME_PROCESSED, 1)
+            final BlockState newBlockState = woodenFrameBlock.defaultBlockState()
                     .setValue(SHAPE, blockState.getValue(SHAPE)).setValue(FACING, blockState.getValue(FACING));
 
             level.setBlock(blockPos, newBlockState, 10);

--- a/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
@@ -16,14 +16,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.registries.RegistryObject;
 
-import java.util.function.Supplier;
-
 public class AngledBoatFrameBlock extends SquaredAngleBlock {
-
-    @Deprecated
-    public AngledBoatFrameBlock(final Supplier<BlockState> blockState, final Properties properties) {
-        super(blockState, properties);
-    }
 
     public AngledBoatFrameBlock(final Properties properties) {
         super(properties);

--- a/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/AngledBoatFrameBlock.java
@@ -20,11 +20,17 @@ import java.util.function.Supplier;
 
 public class AngledBoatFrameBlock extends SquaredAngleBlock {
 
+    @Deprecated
     public AngledBoatFrameBlock(final Supplier<BlockState> blockState, final Properties properties) {
         super(blockState, properties);
     }
 
+    public AngledBoatFrameBlock(final Properties properties) {
+        super(properties);
+    }
+
     @Override
+    @SuppressWarnings("deprecation")
     public InteractionResult use(final BlockState blockState, final Level level, final BlockPos blockPos,
             final Player player, final InteractionHand hand, final BlockHitResult hitResult) {
         // Don't do logic on client side

--- a/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
@@ -8,6 +8,7 @@ import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.common.blocks.wood.Wood;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.Metal;
+import net.dries007.tfc.util.registry.RegistryWood;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
@@ -20,11 +21,12 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class FirmacivBlocks {
+public final class FirmacivBlocks {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS,
             Firmaciv.MOD_ID);
 
@@ -58,15 +60,25 @@ public class FirmacivBlocks {
             () -> new AngledBoatFrameBlock(Blocks.ACACIA_STAIRS.defaultBlockState(),
                     BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS).noOcclusion()));
 
-    public static final Map<Wood, RegistryObject<Block>> WOOD_WATERCRAFT_FRAME_ANGLED = Helpers.mapOfKeys(Wood.class, wood ->
-            registerBlockWithoutItem("wood/" + wood.getSerializedName() + "/watercraft_frame_angled",
-                    () -> new WoodenBoatFrameBlock(wood,
-                            wood.getBlock(Wood.BlockType.STAIRS).get().defaultBlockState(),
-                            BlockBehaviour.Properties.copy(WATERCRAFT_FRAME_ANGLED.get()))));
+    public static final Map<RegistryWood, RegistryObject<Block>> WOOD_WATERCRAFT_FRAME_ANGLED = registerWoodenBoatFrames();
 
     public static final RegistryObject<Block> OARLOCK = registerBlockWithItem("oarlock",
             () -> new OarlockBlock(BlockBehaviour.Properties.copy(
                     TFCBlocks.METALS.get(Metal.Default.WROUGHT_IRON).get(Metal.BlockType.BLOCK).get()).noOcclusion()));
+
+    public static Map<RegistryWood, RegistryObject<Block>> registerWoodenBoatFrames() {
+        final Map<RegistryWood, RegistryObject<Block>> map = new HashMap<>();
+
+        for (final Wood tfcWood : Wood.values()) {
+            map.put(tfcWood,
+                    registerBlockWithoutItem("wood/" + tfcWood.getSerializedName() + "/watercraft_frame_angled",
+                            () -> new WoodenBoatFrameBlock(tfcWood,
+                                    tfcWood.getBlock(Wood.BlockType.STAIRS).get().defaultBlockState(),
+                                    BlockBehaviour.Properties.copy(WATERCRAFT_FRAME_ANGLED.get()))));
+        }
+
+        return map;
+    }
 
     private static <T extends Block> RegistryObject<T> registerBlockWithoutItem(String name, Supplier<T> block) {
         return BLOCKS.register(name, block);

--- a/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
@@ -57,8 +57,7 @@ public final class FirmacivBlocks {
             () -> new Block(BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS).noOcclusion()));
 
     public static final RegistryObject<Block> WATERCRAFT_FRAME_ANGLED = registerBlockWithItem("watercraft_frame_angled",
-            () -> new AngledBoatFrameBlock(Blocks.ACACIA_STAIRS::defaultBlockState,
-                    BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS).noOcclusion()));
+            () -> new AngledBoatFrameBlock(BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS).noOcclusion()));
 
     public static final Map<RegistryWood, RegistryObject<Block>> WOOD_WATERCRAFT_FRAME_ANGLED = registerWoodenBoatFrames();
 
@@ -73,7 +72,6 @@ public final class FirmacivBlocks {
             map.put(tfcWood,
                     registerBlockWithoutItem("wood/" + tfcWood.getSerializedName() + "/watercraft_frame_angled",
                             () -> new WoodenBoatFrameBlock(tfcWood,
-                                    () -> tfcWood.getBlock(Wood.BlockType.STAIRS).get().defaultBlockState(),
                                     BlockBehaviour.Properties.copy(WATERCRAFT_FRAME_ANGLED.get()))));
         }
 

--- a/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
@@ -57,7 +57,7 @@ public final class FirmacivBlocks {
             () -> new Block(BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS).noOcclusion()));
 
     public static final RegistryObject<Block> WATERCRAFT_FRAME_ANGLED = registerBlockWithItem("watercraft_frame_angled",
-            () -> new AngledBoatFrameBlock(Blocks.ACACIA_STAIRS.defaultBlockState(),
+            () -> new AngledBoatFrameBlock(Blocks.ACACIA_STAIRS::defaultBlockState,
                     BlockBehaviour.Properties.copy(Blocks.OAK_PLANKS).noOcclusion()));
 
     public static final Map<RegistryWood, RegistryObject<Block>> WOOD_WATERCRAFT_FRAME_ANGLED = registerWoodenBoatFrames();

--- a/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/FirmacivBlocks.java
@@ -73,7 +73,7 @@ public final class FirmacivBlocks {
             map.put(tfcWood,
                     registerBlockWithoutItem("wood/" + tfcWood.getSerializedName() + "/watercraft_frame_angled",
                             () -> new WoodenBoatFrameBlock(tfcWood,
-                                    tfcWood.getBlock(Wood.BlockType.STAIRS).get().defaultBlockState(),
+                                    () -> tfcWood.getBlock(Wood.BlockType.STAIRS).get().defaultBlockState(),
                                     BlockBehaviour.Properties.copy(WATERCRAFT_FRAME_ANGLED.get()))));
         }
 

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -2,14 +2,8 @@ package com.hyperdash.firmaciv.common.block;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.Explosion;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -19,7 +13,6 @@ import net.minecraft.world.level.block.state.properties.*;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.pathfinder.PathComputationType;
-import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -47,8 +40,6 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     protected static final VoxelShape[] BOTTOM_SHAPES = makeShapes(BOTTOM_AABB, OCTET_NPN, OCTET_PPN, OCTET_NPP,
             OCTET_PPP);
     private static final int[] SHAPE_BY_STATE = new int[]{12, 5, 3, 10, 14, 13, 7, 11, 13, 7, 11, 14, 8, 4, 1, 2, 4, 1, 2, 8};
-    protected final Block base;
-    protected final BlockState baseState;
     // Forge Start
     protected final java.util.function.Supplier<BlockState> stateSupplier;
 
@@ -57,8 +48,6 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
         this.registerDefaultState(
                 this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
                         .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, Boolean.valueOf(false)));
-        this.base = Blocks.AIR; // These are unused, fields are redirected
-        this.baseState = Blocks.AIR.defaultBlockState();
         this.stateSupplier = state;
     }
 
@@ -167,60 +156,6 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
 
     private int getShapeIndex(BlockState pState) {
         return pState.getValue(SHAPE).ordinal() * 4 + pState.getValue(FACING).get2DDataValue();
-    }
-
-    public void attack(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer) {
-        this.baseState.attack(pLevel, pPos, pPlayer);
-    }
-
-    /**
-     * Called after this block has been removed by a player.
-     */
-    public void destroy(LevelAccessor pLevel, BlockPos pPos, BlockState pState) {
-        this.base.destroy(pLevel, pPos, pState);
-    }
-
-    /**
-     * @return how much this block resists an explosion
-     */
-    public float getExplosionResistance() {
-        return this.base.getExplosionResistance();
-    }
-
-    public void onPlace(BlockState pState, Level pLevel, BlockPos pPos, BlockState pOldState, boolean pIsMoving) {
-        if (!pState.is(pState.getBlock())) {
-            this.baseState.neighborChanged(pLevel, pPos, Blocks.AIR, pPos, false);
-            this.base.onPlace(this.baseState, pLevel, pPos, pOldState, false);
-        }
-    }
-
-    public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
-        if (!pState.is(pNewState.getBlock())) {
-            this.baseState.onRemove(pLevel, pPos, pNewState, pIsMoving);
-        }
-    }
-
-    public void stepOn(Level pLevel, BlockPos pPos, BlockState pState, Entity pEntity) {
-        this.base.stepOn(pLevel, pPos, pState, pEntity);
-    }
-
-    /**
-     * @return whether this block needs random ticking.
-     */
-    public boolean isRandomlyTicking(BlockState pState) {
-        return this.base.isRandomlyTicking(pState);
-    }
-
-    public InteractionResult use(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand,
-            BlockHitResult pHit) {
-        return this.baseState.use(pLevel, pPlayer, pHand, pHit);
-    }
-
-    /**
-     * Called when this Block is destroyed by an Explosion
-     */
-    public void wasExploded(Level pLevel, BlockPos pPos, Explosion pExplosion) {
-        this.base.wasExploded(pLevel, pPos, pExplosion);
     }
 
     public BlockState getStateForPlacement(BlockPlaceContext pContext) {

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -22,7 +22,6 @@ import java.util.stream.IntStream;
 
 public abstract class SquaredAngleBlock extends Block implements SimpleWaterloggedBlock {
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
-    public static final EnumProperty<Half> HALF = BlockStateProperties.HALF;
     public static final EnumProperty<StairsShape> SHAPE = BlockStateProperties.STAIRS_SHAPE;
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 
@@ -46,8 +45,8 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     public SquaredAngleBlock(final Supplier<BlockState> stateSupplier, final Properties properties) {
         super(properties);
         this.registerDefaultState(
-                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
-                        .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, false));
+                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(SHAPE, StairsShape.STRAIGHT)
+                        .setValue(WATERLOGGED, false));
         this.stateSupplier = stateSupplier;
     }
 
@@ -109,7 +108,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
             final BlockPos blockPos) {
         final Direction direction = blockState.getValue(FACING);
         final BlockState blockstate = blockGetter.getBlockState(blockPos.relative(direction));
-        if (isRoof(blockstate) && blockState.getValue(HALF) == blockstate.getValue(HALF)) {
+        if (isRoof(blockstate)) {
             final Direction direction1 = blockstate.getValue(FACING);
             if (direction1.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState, blockGetter,
                     blockPos, direction1.getOpposite())) {
@@ -122,7 +121,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
         }
 
         final BlockState blockstate1 = blockGetter.getBlockState(blockPos.relative(direction.getOpposite()));
-        if (isRoof(blockstate1) && blockState.getValue(HALF) == blockstate1.getValue(HALF)) {
+        if (isRoof(blockstate1)) {
             final Direction direction2 = blockstate1.getValue(FACING);
             if (direction2.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState, blockGetter,
                     blockPos, direction2)) {
@@ -140,8 +139,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     private static boolean canTakeShape(final BlockState blockState, final BlockGetter blockGetter,
             final BlockPos blockPos, final Direction direction) {
         final BlockState blockstate = blockGetter.getBlockState(blockPos.relative(direction));
-        return !isRoof(blockstate) || blockstate.getValue(FACING) != blockState.getValue(FACING) || blockstate.getValue(
-                HALF) != blockState.getValue(HALF);
+        return !isRoof(blockstate) || blockstate.getValue(FACING) != blockState.getValue(FACING);
     }
 
     public static boolean isRoof(final BlockState blockState) {
@@ -158,8 +156,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     @SuppressWarnings("deprecation")
     public VoxelShape getShape(final BlockState blockState, final BlockGetter blockGetter, final BlockPos blockPos,
             final CollisionContext context) {
-        return (blockState.getValue(HALF) == Half.TOP ? TOP_SHAPES : BOTTOM_SHAPES)[SHAPE_BY_STATE[this.getShapeIndex(
-                blockState)]];
+        return BOTTOM_SHAPES[SHAPE_BY_STATE[this.getShapeIndex(blockState)]];
     }
 
     private int getShapeIndex(final BlockState blockState) {
@@ -168,11 +165,10 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
 
     @Override
     public BlockState getStateForPlacement(final BlockPlaceContext placeContext) {
-        final Direction direction = placeContext.getClickedFace();
         final BlockPos blockpos = placeContext.getClickedPos();
         final FluidState fluidstate = placeContext.getLevel().getFluidState(blockpos);
         final BlockState blockstate = this.defaultBlockState().setValue(FACING, placeContext.getHorizontalDirection())
-                .setValue(HALF, Half.BOTTOM).setValue(WATERLOGGED, fluidstate.getType() == Fluids.WATER);
+                .setValue(WATERLOGGED, fluidstate.getType() == Fluids.WATER);
 
         return blockstate.setValue(SHAPE, getStairsShape(blockstate, placeContext.getLevel(), blockpos));
     }
@@ -241,7 +237,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
 
     @Override
     protected void createBlockStateDefinition(final StateDefinition.Builder<Block, BlockState> builder) {
-        builder.add(FACING, HALF, SHAPE, WATERLOGGED);
+        builder.add(FACING, SHAPE, WATERLOGGED);
     }
 
     @Override

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -82,7 +82,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     }
 
     private static VoxelShape[] makeShapes(VoxelShape pSlabShape, VoxelShape pNwCorner, VoxelShape pNeCorner,
-                                           VoxelShape pSwCorner, VoxelShape pSeCorner) {
+            VoxelShape pSwCorner, VoxelShape pSeCorner) {
         return IntStream.range(0, 16).mapToObj((p_56945_) -> {
             return makeStairShape(p_56945_, pSlabShape, pNwCorner, pNeCorner, pSwCorner, pSeCorner);
         }).toArray((p_56949_) -> {
@@ -94,7 +94,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
      * Combines the shapes according to the mode set in the bitfield
      */
     private static VoxelShape makeStairShape(int pBitfield, VoxelShape pSlabShape, VoxelShape pNwCorner,
-                                             VoxelShape pNeCorner, VoxelShape pSwCorner, VoxelShape pSeCorner) {
+            VoxelShape pNeCorner, VoxelShape pSwCorner, VoxelShape pSeCorner) {
 
         double move = -0.5D;
         if (pSlabShape == TOP_AABB) {
@@ -231,7 +231,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     }
 
     public InteractionResult use(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand,
-                                 BlockHitResult pHit) {
+            BlockHitResult pHit) {
         return this.baseState.use(pLevel, pPlayer, pHand, pHit);
     }
 
@@ -258,7 +258,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
      * Note that this method should ideally consider only the specific direction passed in.
      */
     public BlockState updateShape(BlockState pState, Direction pFacing, BlockState pFacingState, LevelAccessor pLevel,
-                                  BlockPos pCurrentPos, BlockPos pFacingPos) {
+            BlockPos pCurrentPos, BlockPos pFacingPos) {
         if (pState.getValue(WATERLOGGED)) {
             pLevel.scheduleTick(pCurrentPos, Fluids.WATER, Fluids.WATER.getTickDelay(pLevel));
         }

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -24,17 +24,15 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
     public static final EnumProperty<StairsShape> SHAPE = BlockStateProperties.STAIRS_SHAPE;
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
-
-    protected static final VoxelShape TOP_AABB = Block.box(0.0D, 8.0D, 0.0D, 16.0D, 16.0D, 16.0D);
-    protected static final VoxelShape BOTTOM_AABB = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 8.0D, 16.0D);
-    protected static final VoxelShape OCTET_NPN = Block.box(0.0D, 8.0D, 0.0D, 8.0D, 16.0D, 8.0D);
-    protected static final VoxelShape OCTET_NPP = Block.box(0.0D, 8.0D, 8.0D, 8.0D, 16.0D, 16.0D);
-    protected static final VoxelShape OCTET_PPN = Block.box(8.0D, 8.0D, 0.0D, 16.0D, 16.0D, 8.0D);
-    protected static final VoxelShape OCTET_PPP = Block.box(8.0D, 8.0D, 8.0D, 16.0D, 16.0D, 16.0D);
+    protected static final VoxelShape TOP_AABB = Block.box(0, 8, 0, 16, 16, 16);
+    protected static final VoxelShape BOTTOM_AABB = Block.box(0, 0, 0, 16, 8, 16);
+    protected static final VoxelShape OCTET_NPN = Block.box(0, 8, 0, 8, 16, 8);
+    protected static final VoxelShape OCTET_NPP = Block.box(0, 8, 8, 8, 16, 16);
+    protected static final VoxelShape OCTET_PPN = Block.box(8, 8, 0, 16, 16, 8);
+    protected static final VoxelShape OCTET_PPP = Block.box(8, 8, 8, 16, 16, 16);
     protected static final VoxelShape[] BOTTOM_SHAPES = makeShapes(BOTTOM_AABB, OCTET_NPN, OCTET_PPN, OCTET_NPP,
             OCTET_PPP);
     private static final int[] SHAPE_BY_STATE = new int[]{12, 5, 3, 10, 14, 13, 7, 11, 13, 7, 11, 14, 8, 4, 1, 2, 4, 1, 2, 8};
-    // Forge Start
     protected final Supplier<BlockState> stateSupplier;
 
     public SquaredAngleBlock(final Supplier<BlockState> stateSupplier, final Properties properties) {
@@ -45,6 +43,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
         this.stateSupplier = stateSupplier;
     }
 
+    @SuppressWarnings("SameParameterValue")
     private static VoxelShape[] makeShapes(final VoxelShape slabShape, final VoxelShape northWestCorner,
             final VoxelShape northEastCorner, final VoxelShape southWestCorner, final VoxelShape southEastCorner) {
         return IntStream.range(0, 16).mapToObj(
@@ -102,25 +101,27 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     private static StairsShape getStairsShape(final BlockState blockState, final BlockGetter blockGetter,
             final BlockPos blockPos) {
         final Direction direction = blockState.getValue(FACING);
-        final BlockState blockstate = blockGetter.getBlockState(blockPos.relative(direction));
-        if (isAngledFrame(blockstate)) {
-            final Direction direction1 = blockstate.getValue(FACING);
-            if (direction1.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState, blockGetter,
-                    blockPos, direction1.getOpposite())) {
-                if (direction1 == direction.getCounterClockWise()) {
-                    return StairsShape.OUTER_LEFT;
-                }
+        {
+            final BlockState neighborBlockState = blockGetter.getBlockState(blockPos.relative(direction));
+            if (isAngledFrame(neighborBlockState)) {
+                final Direction neighborFacing = neighborBlockState.getValue(FACING);
+                if (neighborFacing.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState,
+                        blockGetter, blockPos, neighborFacing.getOpposite())) {
+                    if (neighborFacing == direction.getCounterClockWise()) {
+                        return StairsShape.OUTER_LEFT;
+                    }
 
-                return StairsShape.OUTER_RIGHT;
+                    return StairsShape.OUTER_RIGHT;
+                }
             }
         }
 
-        final BlockState blockstate1 = blockGetter.getBlockState(blockPos.relative(direction.getOpposite()));
-        if (isAngledFrame(blockstate1)) {
-            final Direction direction2 = blockstate1.getValue(FACING);
-            if (direction2.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState, blockGetter,
-                    blockPos, direction2)) {
-                if (direction2 == direction.getCounterClockWise()) {
+        final BlockState neighborBlockState = blockGetter.getBlockState(blockPos.relative(direction.getOpposite()));
+        if (isAngledFrame(neighborBlockState)) {
+            final Direction neighborFacing = neighborBlockState.getValue(FACING);
+            if (neighborFacing.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState,
+                    blockGetter, blockPos, neighborFacing)) {
+                if (neighborFacing == direction.getCounterClockWise()) {
                     return StairsShape.INNER_LEFT;
                 }
 
@@ -246,13 +247,5 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     public boolean isPathfindable(final BlockState blockState, final BlockGetter blockGetter, final BlockPos blockPos,
             final PathComputationType computationType) {
         return false;
-    }
-
-    private Block getModelBlock() {
-        return getModelState().getBlock();
-    }
-
-    private BlockState getModelState() {
-        return stateSupplier.get();
     }
 }

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -145,10 +145,14 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
         return pState.getBlock() instanceof SquaredAngleBlock;
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
     public boolean useShapeForLightOcclusion(BlockState pState) {
         return true;
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
     public VoxelShape getShape(BlockState pState, BlockGetter pLevel, BlockPos pPos, CollisionContext pContext) {
         return (pState.getValue(HALF) == Half.TOP ? TOP_SHAPES : BOTTOM_SHAPES)[SHAPE_BY_STATE[this.getShapeIndex(
                 pState)]];
@@ -158,6 +162,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
         return pState.getValue(SHAPE).ordinal() * 4 + pState.getValue(FACING).get2DDataValue();
     }
 
+    @Override
     public BlockState getStateForPlacement(BlockPlaceContext pContext) {
         Direction direction = pContext.getClickedFace();
         BlockPos blockpos = pContext.getClickedPos();
@@ -167,12 +172,8 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
         return blockstate.setValue(SHAPE, getStairsShape(blockstate, pContext.getLevel(), blockpos));
     }
 
-    /**
-     * Update the provided state given the provided neighbor direction and neighbor state, returning a new state.
-     * For example, fences make their connections to the passed in state if possible, and wet concrete powder immediately
-     * returns its solidified counterpart.
-     * Note that this method should ideally consider only the specific direction passed in.
-     */
+    @Override
+    @SuppressWarnings("deprecation")
     public BlockState updateShape(BlockState pState, Direction pFacing, BlockState pFacingState, LevelAccessor pLevel,
             BlockPos pCurrentPos, BlockPos pFacingPos) {
         if (pState.getValue(WATERLOGGED)) {
@@ -184,10 +185,14 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
                 pCurrentPos, pFacingPos);
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
     public BlockState rotate(BlockState pState, Rotation pRot) {
         return pState.setValue(FACING, pRot.rotate(pState.getValue(FACING)));
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState pState, Mirror pMirror) {
         Direction direction = pState.getValue(FACING);
         StairsShape stairsshape = pState.getValue(SHAPE);
@@ -228,14 +233,19 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
         return super.mirror(pState, pMirror);
     }
 
+    @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> pBuilder) {
         pBuilder.add(FACING, HALF, SHAPE, WATERLOGGED);
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
     public FluidState getFluidState(BlockState pState) {
         return pState.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(pState);
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
     public boolean isPathfindable(BlockState pState, BlockGetter pLevel, BlockPos pPos, PathComputationType pType) {
         return false;
     }
@@ -247,5 +257,4 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     private BlockState getModelState() {
         return stateSupplier.get();
     }
-    // Forge end
 }

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -35,6 +35,9 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
 
     public SquaredAngleBlock(final Properties properties) {
         super(properties);
+        this.registerDefaultState(
+                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(SHAPE, StairsShape.STRAIGHT)
+                        .setValue(WATERLOGGED, false));
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -17,7 +17,6 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
-import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 public abstract class SquaredAngleBlock extends Block implements SimpleWaterloggedBlock {
@@ -33,20 +32,9 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     protected static final VoxelShape[] BOTTOM_SHAPES = makeShapes(BOTTOM_AABB, OCTET_NPN, OCTET_PPN, OCTET_NPP,
             OCTET_PPP);
     private static final int[] SHAPE_BY_STATE = new int[]{12, 5, 3, 10, 14, 13, 7, 11, 13, 7, 11, 14, 8, 4, 1, 2, 4, 1, 2, 8};
-    protected final Supplier<BlockState> stateSupplier;
-
-    @Deprecated
-    public SquaredAngleBlock(final Supplier<BlockState> stateSupplier, final Properties properties) {
-        super(properties);
-        this.registerDefaultState(
-                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(SHAPE, StairsShape.STRAIGHT)
-                        .setValue(WATERLOGGED, false));
-        this.stateSupplier = stateSupplier;
-    }
 
     public SquaredAngleBlock(final Properties properties) {
         super(properties);
-        stateSupplier = Blocks.AIR::defaultBlockState;
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -52,25 +52,6 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     // Forge Start
     protected final java.util.function.Supplier<BlockState> stateSupplier;
 
-    @Deprecated // Forge: Use the other constructor that takes a Supplier
-    public SquaredAngleBlock(BlockState pBaseState, BlockBehaviour.Properties pProperties) {
-        super(pProperties);
-        this.registerDefaultState(
-                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
-                        .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, Boolean.valueOf(false)));
-        this.base = pBaseState.getBlock();
-        this.baseState = pBaseState;
-        this.stateSupplier = () -> pBaseState;
-    }
-
-    @Deprecated // Forge: Use the other constructor that takes a Supplier
-    public SquaredAngleBlock(BlockBehaviour.Properties pProperties) {
-        super(pProperties);
-        this.base = Blocks.AIR; // These are unused, fields are redirected
-        this.baseState = Blocks.AIR.defaultBlockState();
-        this.stateSupplier = () -> baseState;
-    }
-
     public SquaredAngleBlock(java.util.function.Supplier<BlockState> state, BlockBehaviour.Properties properties) {
         super(properties);
         this.registerDefaultState(

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -27,15 +27,10 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
 
     protected static final VoxelShape TOP_AABB = Block.box(0.0D, 8.0D, 0.0D, 16.0D, 16.0D, 16.0D);
     protected static final VoxelShape BOTTOM_AABB = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 8.0D, 16.0D);
-    protected static final VoxelShape OCTET_NNN = Block.box(0.0D, 0.0D, 0.0D, 8.0D, 8.0D, 8.0D);
-    protected static final VoxelShape OCTET_NNP = Block.box(0.0D, 0.0D, 8.0D, 8.0D, 8.0D, 16.0D);
     protected static final VoxelShape OCTET_NPN = Block.box(0.0D, 8.0D, 0.0D, 8.0D, 16.0D, 8.0D);
     protected static final VoxelShape OCTET_NPP = Block.box(0.0D, 8.0D, 8.0D, 8.0D, 16.0D, 16.0D);
-    protected static final VoxelShape OCTET_PNN = Block.box(8.0D, 0.0D, 0.0D, 16.0D, 8.0D, 8.0D);
-    protected static final VoxelShape OCTET_PNP = Block.box(8.0D, 0.0D, 8.0D, 16.0D, 8.0D, 16.0D);
     protected static final VoxelShape OCTET_PPN = Block.box(8.0D, 8.0D, 0.0D, 16.0D, 16.0D, 8.0D);
     protected static final VoxelShape OCTET_PPP = Block.box(8.0D, 8.0D, 8.0D, 16.0D, 16.0D, 16.0D);
-    protected static final VoxelShape[] TOP_SHAPES = makeShapes(TOP_AABB, OCTET_NNN, OCTET_PNN, OCTET_NNP, OCTET_PNP);
     protected static final VoxelShape[] BOTTOM_SHAPES = makeShapes(BOTTOM_AABB, OCTET_NPN, OCTET_PPN, OCTET_NPP,
             OCTET_PPP);
     private static final int[] SHAPE_BY_STATE = new int[]{12, 5, 3, 10, 14, 13, 7, 11, 13, 7, 11, 14, 8, 4, 1, 2, 4, 1, 2, 8};

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -103,7 +103,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
             final BlockPos blockPos) {
         final Direction direction = blockState.getValue(FACING);
         final BlockState blockstate = blockGetter.getBlockState(blockPos.relative(direction));
-        if (isRoof(blockstate)) {
+        if (isAngledFrame(blockstate)) {
             final Direction direction1 = blockstate.getValue(FACING);
             if (direction1.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState, blockGetter,
                     blockPos, direction1.getOpposite())) {
@@ -116,7 +116,7 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
         }
 
         final BlockState blockstate1 = blockGetter.getBlockState(blockPos.relative(direction.getOpposite()));
-        if (isRoof(blockstate1)) {
+        if (isAngledFrame(blockstate1)) {
             final Direction direction2 = blockstate1.getValue(FACING);
             if (direction2.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState, blockGetter,
                     blockPos, direction2)) {
@@ -134,10 +134,10 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     private static boolean canTakeShape(final BlockState blockState, final BlockGetter blockGetter,
             final BlockPos blockPos, final Direction direction) {
         final BlockState blockstate = blockGetter.getBlockState(blockPos.relative(direction));
-        return !isRoof(blockstate) || blockstate.getValue(FACING) != blockState.getValue(FACING);
+        return !isAngledFrame(blockstate) || blockstate.getValue(FACING) != blockState.getValue(FACING);
     }
 
-    public static boolean isRoof(final BlockState blockState) {
+    public static boolean isAngledFrame(final BlockState blockState) {
         return blockState.getBlock() instanceof SquaredAngleBlock;
     }
 

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -6,7 +6,6 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.*;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.*;
@@ -18,6 +17,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 public abstract class SquaredAngleBlock extends Block implements SimpleWaterloggedBlock {
@@ -41,61 +41,62 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
             OCTET_PPP);
     private static final int[] SHAPE_BY_STATE = new int[]{12, 5, 3, 10, 14, 13, 7, 11, 13, 7, 11, 14, 8, 4, 1, 2, 4, 1, 2, 8};
     // Forge Start
-    protected final java.util.function.Supplier<BlockState> stateSupplier;
+    protected final Supplier<BlockState> stateSupplier;
 
-    public SquaredAngleBlock(java.util.function.Supplier<BlockState> state, BlockBehaviour.Properties properties) {
+    public SquaredAngleBlock(final Supplier<BlockState> stateSupplier, final Properties properties) {
         super(properties);
         this.registerDefaultState(
                 this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
-                        .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, Boolean.valueOf(false)));
-        this.stateSupplier = state;
+                        .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, false));
+        this.stateSupplier = stateSupplier;
     }
 
-    private static VoxelShape[] makeShapes(VoxelShape pSlabShape, VoxelShape pNwCorner, VoxelShape pNeCorner,
-            VoxelShape pSwCorner, VoxelShape pSeCorner) {
-        return IntStream.range(0, 16).mapToObj((p_56945_) -> {
-            return makeStairShape(p_56945_, pSlabShape, pNwCorner, pNeCorner, pSwCorner, pSeCorner);
-        }).toArray((p_56949_) -> {
-            return new VoxelShape[p_56949_];
-        });
+    private static VoxelShape[] makeShapes(final VoxelShape slabShape, final VoxelShape northWestCorner,
+            final VoxelShape northEastCorner, final VoxelShape southWestCorner, final VoxelShape southEastCorner) {
+        return IntStream.range(0, 16).mapToObj(
+                (bitfield) -> makeStairShape(bitfield, slabShape, northWestCorner, northEastCorner, southWestCorner,
+                        southEastCorner)).toArray(VoxelShape[]::new);
     }
 
     /**
      * Combines the shapes according to the mode set in the bitfield
      */
-    private static VoxelShape makeStairShape(int pBitfield, VoxelShape pSlabShape, VoxelShape pNwCorner,
-            VoxelShape pNeCorner, VoxelShape pSwCorner, VoxelShape pSeCorner) {
+    private static VoxelShape makeStairShape(final int bitfield, final VoxelShape slabShape,
+            final VoxelShape northWestCorner, final VoxelShape northEastCorner, final VoxelShape southWestCorner,
+            final VoxelShape southEastCorner) {
 
-        double move = -0.5D;
-        if (pSlabShape == TOP_AABB) {
-            move = 0.5D;
+        final VoxelShape northWestCornerOpposite;
+        final VoxelShape northEastCornerOpposite;
+        final VoxelShape southWestCornerOpposite;
+        final VoxelShape southEastCornerOpposite;
+        {
+            final double move = slabShape == TOP_AABB ? 0.5 : -0.5;
+
+            northWestCornerOpposite = northWestCorner.move(0, move, 0);
+            northEastCornerOpposite = northEastCorner.move(0, move, 0);
+            southWestCornerOpposite = southWestCorner.move(0, move, 0);
+            southEastCornerOpposite = southEastCorner.move(0, move, 0);
         }
 
-        VoxelShape NwCornerOpposite = pNwCorner.move(0, move, 0);
-        VoxelShape NeCornerOpposite = pNeCorner.move(0, move, 0);
-        VoxelShape SwCornerOpposite = pSwCorner.move(0, move, 0);
-        VoxelShape SeCornerOpposite = pSeCorner.move(0, move, 0);
-
-
-        VoxelShape voxelshape = pSlabShape;
-        if ((pBitfield & 1) != 0) {
-            voxelshape = Shapes.or(pSlabShape, pNwCorner);
-            voxelshape = Shapes.join(voxelshape, NwCornerOpposite, BooleanOp.ONLY_FIRST);
+        VoxelShape voxelshape = slabShape;
+        if ((bitfield & 1) != 0) {
+            voxelshape = Shapes.or(slabShape, northWestCorner);
+            voxelshape = Shapes.join(voxelshape, northWestCornerOpposite, BooleanOp.ONLY_FIRST);
         }
 
-        if ((pBitfield & 2) != 0) {
-            voxelshape = Shapes.or(voxelshape, pNeCorner);
-            voxelshape = Shapes.join(voxelshape, NeCornerOpposite, BooleanOp.ONLY_FIRST);
+        if ((bitfield & 2) != 0) {
+            voxelshape = Shapes.or(voxelshape, northEastCorner);
+            voxelshape = Shapes.join(voxelshape, northEastCornerOpposite, BooleanOp.ONLY_FIRST);
         }
 
-        if ((pBitfield & 4) != 0) {
-            voxelshape = Shapes.or(voxelshape, pSwCorner);
-            voxelshape = Shapes.join(voxelshape, SwCornerOpposite, BooleanOp.ONLY_FIRST);
+        if ((bitfield & 4) != 0) {
+            voxelshape = Shapes.or(voxelshape, southWestCorner);
+            voxelshape = Shapes.join(voxelshape, southWestCornerOpposite, BooleanOp.ONLY_FIRST);
         }
 
-        if ((pBitfield & 8) != 0) {
-            voxelshape = Shapes.or(voxelshape, pSeCorner);
-            voxelshape = Shapes.join(voxelshape, SeCornerOpposite, BooleanOp.ONLY_FIRST);
+        if ((bitfield & 8) != 0) {
+            voxelshape = Shapes.or(voxelshape, southEastCorner);
+            voxelshape = Shapes.join(voxelshape, southEastCornerOpposite, BooleanOp.ONLY_FIRST);
         }
 
         return voxelshape;
@@ -104,13 +105,14 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     /**
      * Returns a stair shape property based on the surrounding stairs from the given blockstate and position
      */
-    private static StairsShape getStairsShape(BlockState pState, BlockGetter pLevel, BlockPos pPos) {
-        Direction direction = pState.getValue(FACING);
-        BlockState blockstate = pLevel.getBlockState(pPos.relative(direction));
-        if (isRoof(blockstate) && pState.getValue(HALF) == blockstate.getValue(HALF)) {
-            Direction direction1 = blockstate.getValue(FACING);
-            if (direction1.getAxis() != pState.getValue(FACING).getAxis() && canTakeShape(pState, pLevel, pPos,
-                    direction1.getOpposite())) {
+    private static StairsShape getStairsShape(final BlockState blockState, final BlockGetter blockGetter,
+            final BlockPos blockPos) {
+        final Direction direction = blockState.getValue(FACING);
+        final BlockState blockstate = blockGetter.getBlockState(blockPos.relative(direction));
+        if (isRoof(blockstate) && blockState.getValue(HALF) == blockstate.getValue(HALF)) {
+            final Direction direction1 = blockstate.getValue(FACING);
+            if (direction1.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState, blockGetter,
+                    blockPos, direction1.getOpposite())) {
                 if (direction1 == direction.getCounterClockWise()) {
                     return StairsShape.OUTER_LEFT;
                 }
@@ -119,11 +121,11 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
             }
         }
 
-        BlockState blockstate1 = pLevel.getBlockState(pPos.relative(direction.getOpposite()));
-        if (isRoof(blockstate1) && pState.getValue(HALF) == blockstate1.getValue(HALF)) {
-            Direction direction2 = blockstate1.getValue(FACING);
-            if (direction2.getAxis() != pState.getValue(FACING).getAxis() && canTakeShape(pState, pLevel, pPos,
-                    direction2)) {
+        final BlockState blockstate1 = blockGetter.getBlockState(blockPos.relative(direction.getOpposite()));
+        if (isRoof(blockstate1) && blockState.getValue(HALF) == blockstate1.getValue(HALF)) {
+            final Direction direction2 = blockstate1.getValue(FACING);
+            if (direction2.getAxis() != blockState.getValue(FACING).getAxis() && canTakeShape(blockState, blockGetter,
+                    blockPos, direction2)) {
                 if (direction2 == direction.getCounterClockWise()) {
                     return StairsShape.INNER_LEFT;
                 }
@@ -135,118 +137,123 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
         return StairsShape.STRAIGHT;
     }
 
-    private static boolean canTakeShape(BlockState pState, BlockGetter pLevel, BlockPos pPos, Direction pFace) {
-        BlockState blockstate = pLevel.getBlockState(pPos.relative(pFace));
-        return !isRoof(blockstate) || blockstate.getValue(FACING) != pState.getValue(FACING) || blockstate.getValue(
-                HALF) != pState.getValue(HALF);
+    private static boolean canTakeShape(final BlockState blockState, final BlockGetter blockGetter,
+            final BlockPos blockPos, final Direction direction) {
+        final BlockState blockstate = blockGetter.getBlockState(blockPos.relative(direction));
+        return !isRoof(blockstate) || blockstate.getValue(FACING) != blockState.getValue(FACING) || blockstate.getValue(
+                HALF) != blockState.getValue(HALF);
     }
 
-    public static boolean isRoof(BlockState pState) {
-        return pState.getBlock() instanceof SquaredAngleBlock;
+    public static boolean isRoof(final BlockState blockState) {
+        return blockState.getBlock() instanceof SquaredAngleBlock;
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public boolean useShapeForLightOcclusion(BlockState pState) {
+    public boolean useShapeForLightOcclusion(final BlockState blockState) {
         return true;
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public VoxelShape getShape(BlockState pState, BlockGetter pLevel, BlockPos pPos, CollisionContext pContext) {
-        return (pState.getValue(HALF) == Half.TOP ? TOP_SHAPES : BOTTOM_SHAPES)[SHAPE_BY_STATE[this.getShapeIndex(
-                pState)]];
+    public VoxelShape getShape(final BlockState blockState, final BlockGetter blockGetter, final BlockPos blockPos,
+            final CollisionContext context) {
+        return (blockState.getValue(HALF) == Half.TOP ? TOP_SHAPES : BOTTOM_SHAPES)[SHAPE_BY_STATE[this.getShapeIndex(
+                blockState)]];
     }
 
-    private int getShapeIndex(BlockState pState) {
-        return pState.getValue(SHAPE).ordinal() * 4 + pState.getValue(FACING).get2DDataValue();
+    private int getShapeIndex(final BlockState blockState) {
+        return blockState.getValue(SHAPE).ordinal() * 4 + blockState.getValue(FACING).get2DDataValue();
     }
 
     @Override
-    public BlockState getStateForPlacement(BlockPlaceContext pContext) {
-        Direction direction = pContext.getClickedFace();
-        BlockPos blockpos = pContext.getClickedPos();
-        FluidState fluidstate = pContext.getLevel().getFluidState(blockpos);
-        BlockState blockstate = this.defaultBlockState().setValue(FACING, pContext.getHorizontalDirection())
+    public BlockState getStateForPlacement(final BlockPlaceContext placeContext) {
+        final Direction direction = placeContext.getClickedFace();
+        final BlockPos blockpos = placeContext.getClickedPos();
+        final FluidState fluidstate = placeContext.getLevel().getFluidState(blockpos);
+        final BlockState blockstate = this.defaultBlockState().setValue(FACING, placeContext.getHorizontalDirection())
                 .setValue(HALF, Half.BOTTOM).setValue(WATERLOGGED, fluidstate.getType() == Fluids.WATER);
-        return blockstate.setValue(SHAPE, getStairsShape(blockstate, pContext.getLevel(), blockpos));
+
+        return blockstate.setValue(SHAPE, getStairsShape(blockstate, placeContext.getLevel(), blockpos));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState updateShape(BlockState pState, Direction pFacing, BlockState pFacingState, LevelAccessor pLevel,
-            BlockPos pCurrentPos, BlockPos pFacingPos) {
-        if (pState.getValue(WATERLOGGED)) {
-            pLevel.scheduleTick(pCurrentPos, Fluids.WATER, Fluids.WATER.getTickDelay(pLevel));
+    public BlockState updateShape(final BlockState blockState, final Direction direction,
+            final BlockState neighborState, final LevelAccessor levelAccessor, final BlockPos blockPos,
+            final BlockPos neighborPos) {
+
+        if (blockState.getValue(WATERLOGGED)) {
+            levelAccessor.scheduleTick(blockPos, Fluids.WATER, Fluids.WATER.getTickDelay(levelAccessor));
         }
 
-        return pFacing.getAxis().isHorizontal() ? pState.setValue(SHAPE,
-                getStairsShape(pState, pLevel, pCurrentPos)) : super.updateShape(pState, pFacing, pFacingState, pLevel,
-                pCurrentPos, pFacingPos);
+        if (direction.getAxis().isHorizontal())
+            return blockState.setValue(SHAPE, getStairsShape(blockState, levelAccessor, blockPos));
+
+        return super.updateShape(blockState, direction, neighborState, levelAccessor, blockPos, neighborPos);
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState pState, Rotation pRot) {
-        return pState.setValue(FACING, pRot.rotate(pState.getValue(FACING)));
+    public BlockState rotate(final BlockState blockState, final Rotation rotation) {
+        return blockState.setValue(FACING, rotation.rotate(blockState.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState pState, Mirror pMirror) {
-        Direction direction = pState.getValue(FACING);
-        StairsShape stairsshape = pState.getValue(SHAPE);
-        switch (pMirror) {
+    public BlockState mirror(final BlockState blockState, final Mirror mirror) {
+        final Direction direction = blockState.getValue(FACING);
+        final StairsShape stairsshape = blockState.getValue(SHAPE);
+        switch (mirror) {
             case LEFT_RIGHT:
                 if (direction.getAxis() == Direction.Axis.Z) {
-                    switch (stairsshape) {
-                        case INNER_LEFT:
-                            return pState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.INNER_RIGHT);
-                        case INNER_RIGHT:
-                            return pState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.INNER_LEFT);
-                        case OUTER_LEFT:
-                            return pState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.OUTER_RIGHT);
-                        case OUTER_RIGHT:
-                            return pState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.OUTER_LEFT);
-                        default:
-                            return pState.rotate(Rotation.CLOCKWISE_180);
-                    }
+                    return switch (stairsshape) {
+                        case INNER_LEFT ->
+                                blockState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.INNER_RIGHT);
+                        case INNER_RIGHT ->
+                                blockState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.INNER_LEFT);
+                        case OUTER_LEFT ->
+                                blockState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.OUTER_RIGHT);
+                        case OUTER_RIGHT ->
+                                blockState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.OUTER_LEFT);
+                        default -> blockState.rotate(Rotation.CLOCKWISE_180);
+                    };
                 }
                 break;
             case FRONT_BACK:
                 if (direction.getAxis() == Direction.Axis.X) {
-                    switch (stairsshape) {
-                        case INNER_LEFT:
-                            return pState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.INNER_LEFT);
-                        case INNER_RIGHT:
-                            return pState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.INNER_RIGHT);
-                        case OUTER_LEFT:
-                            return pState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.OUTER_RIGHT);
-                        case OUTER_RIGHT:
-                            return pState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.OUTER_LEFT);
-                        case STRAIGHT:
-                            return pState.rotate(Rotation.CLOCKWISE_180);
-                    }
+                    return switch (stairsshape) {
+                        case INNER_LEFT ->
+                                blockState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.INNER_LEFT);
+                        case INNER_RIGHT ->
+                                blockState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.INNER_RIGHT);
+                        case OUTER_LEFT ->
+                                blockState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.OUTER_RIGHT);
+                        case OUTER_RIGHT ->
+                                blockState.rotate(Rotation.CLOCKWISE_180).setValue(SHAPE, StairsShape.OUTER_LEFT);
+                        case STRAIGHT -> blockState.rotate(Rotation.CLOCKWISE_180);
+                    };
                 }
         }
 
-        return super.mirror(pState, pMirror);
+        return super.mirror(blockState, mirror);
     }
 
     @Override
-    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> pBuilder) {
-        pBuilder.add(FACING, HALF, SHAPE, WATERLOGGED);
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public FluidState getFluidState(BlockState pState) {
-        return pState.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(pState);
+    protected void createBlockStateDefinition(final StateDefinition.Builder<Block, BlockState> builder) {
+        builder.add(FACING, HALF, SHAPE, WATERLOGGED);
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public boolean isPathfindable(BlockState pState, BlockGetter pLevel, BlockPos pPos, PathComputationType pType) {
+    public FluidState getFluidState(final BlockState blockState) {
+        return blockState.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(blockState);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isPathfindable(final BlockState blockState, final BlockGetter blockGetter, final BlockPos blockPos,
+            final PathComputationType computationType) {
         return false;
     }
 

--- a/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/SquaredAngleBlock.java
@@ -35,12 +35,18 @@ public abstract class SquaredAngleBlock extends Block implements SimpleWaterlogg
     private static final int[] SHAPE_BY_STATE = new int[]{12, 5, 3, 10, 14, 13, 7, 11, 13, 7, 11, 14, 8, 4, 1, 2, 4, 1, 2, 8};
     protected final Supplier<BlockState> stateSupplier;
 
+    @Deprecated
     public SquaredAngleBlock(final Supplier<BlockState> stateSupplier, final Properties properties) {
         super(properties);
         this.registerDefaultState(
                 this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(SHAPE, StairsShape.STRAIGHT)
                         .setValue(WATERLOGGED, false));
         this.stateSupplier = stateSupplier;
+    }
+
+    public SquaredAngleBlock(final Properties properties) {
+        super(properties);
+        stateSupplier = Blocks.AIR::defaultBlockState;
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
@@ -26,22 +26,11 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
-import java.util.function.Supplier;
 
 public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlock {
     public static final IntegerProperty FRAME_PROCESSED = FirmacivBlockStateProperties.FRAME_PROCESSED_7;
 
     public final RegistryWood wood;
-
-    @Deprecated
-    public WoodenBoatFrameBlock(final RegistryWood wood, final Supplier<BlockState> blockState,
-            final Properties properties) {
-        super(blockState, properties);
-        this.registerDefaultState(
-                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(SHAPE, StairsShape.STRAIGHT)
-                        .setValue(WATERLOGGED, false).setValue(FRAME_PROCESSED, 0));
-        this.wood = wood;
-    }
 
     public WoodenBoatFrameBlock(final RegistryWood wood, final Properties properties) {
         super(properties);

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
@@ -20,7 +20,6 @@ import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.properties.Half;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.block.state.properties.StairsShape;
 import net.minecraft.world.phys.BlockHitResult;
@@ -38,13 +37,13 @@ public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlo
             final Properties properties) {
         super(blockState, properties);
         this.registerDefaultState(
-                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
-                        .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, false)
-                        .setValue(FRAME_PROCESSED, 0));
+                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(SHAPE, StairsShape.STRAIGHT)
+                        .setValue(WATERLOGGED, false).setValue(FRAME_PROCESSED, 0));
         this.wood = wood;
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onRemove(final BlockState blockState, final Level level, final BlockPos blockPos,
             final BlockState newState, final boolean isMoving) {
         if (level.getBlockEntity(blockPos) instanceof WatercraftFrameBlockEntity frameBlockEntity) {
@@ -64,6 +63,7 @@ public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlo
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public InteractionResult use(final BlockState blockState, final Level level, final BlockPos blockPos,
             final Player player, final InteractionHand hand, final BlockHitResult hitResult) {
         // Don't do logic on client side

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
@@ -33,8 +33,7 @@ public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlo
 
     public final RegistryWood wood;
 
-    public WoodenBoatFrameBlock(final RegistryWood wood, final BlockState blockState,
-            final Properties properties) {
+    public WoodenBoatFrameBlock(final RegistryWood wood, final BlockState blockState, final Properties properties) {
         super(blockState, properties);
         this.registerDefaultState(
                 this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
@@ -92,6 +91,7 @@ public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlo
             if (0 == processState) {
                 final BlockState newState = FirmacivBlocks.WATERCRAFT_FRAME_ANGLED.get().defaultBlockState()
                         .setValue(SHAPE, blockState.getValue(SHAPE)).setValue(FACING, blockState.getValue(FACING));
+
                 level.setBlock(blockPos, newState, 10);
                 return InteractionResult.SUCCESS;
             }

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
@@ -105,7 +105,14 @@ public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlo
         if (heldStack.is(FirmacivTags.Items.PLANKS)) {
             // Must be [0,3)
             if (3 > processState) {
-                frameBlockEntity.insertPlanks(heldStack.split(1));
+                final ItemStack remainder = frameBlockEntity.insertPlanks(heldStack.split(1));
+
+                // Couldn't put the item in
+                if (!remainder.isEmpty()) {
+                    heldStack.grow(1);
+                    return InteractionResult.SUCCESS;
+                }
+
                 level.setBlock(blockPos, blockState.cycle(FRAME_PROCESSED), 10);
                 level.playSound(null, blockPos, SoundEvents.WOOD_PLACE, SoundSource.BLOCKS, 1.5F,
                         level.getRandom().nextFloat() * 0.1F + 0.9F);

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
@@ -21,25 +21,24 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.Half;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.block.state.properties.StairsShape;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
 
-import static com.hyperdash.firmaciv.common.block.AngledBoatFrameBlock.FRAME_PROCESSED;
-
 public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlock {
+    public static final IntegerProperty FRAME_PROCESSED = FirmacivBlockStateProperties.FRAME_PROCESSED_7;
 
     public final RegistryWood wood;
 
     public WoodenBoatFrameBlock(final RegistryWood wood, final BlockState blockState,
-                                final Properties properties) {
+            final Properties properties) {
         super(blockState, properties);
         this.registerDefaultState(
                 this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)
                         .setValue(SHAPE, StairsShape.STRAIGHT).setValue(WATERLOGGED, false)
-                        // TODO state 0 is no longer actually used as no progress is represented as a separate block
                         .setValue(FRAME_PROCESSED, 0));
         this.wood = wood;
     }
@@ -83,14 +82,14 @@ public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlo
         // Try extract
         if (heldStack.isEmpty()) {
             // Extract an item
-            if (4 >= processState) {
+            if (3 >= processState) {
                 ItemHandlerHelper.giveItemToPlayer(player, frameBlockEntity.extractPlanks(1));
             } else {
                 ItemHandlerHelper.giveItemToPlayer(player, frameBlockEntity.extractBolts(1));
             }
 
             // Set ourselves back to our base
-            if (1 == processState) {
+            if (0 == processState) {
                 final BlockState newState = FirmacivBlocks.WATERCRAFT_FRAME_ANGLED.get().defaultBlockState()
                         .setValue(SHAPE, blockState.getValue(SHAPE)).setValue(FACING, blockState.getValue(FACING));
                 level.setBlock(blockPos, newState, 10);
@@ -104,8 +103,8 @@ public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlo
 
         // Should we do plank stuff
         if (heldStack.is(FirmacivTags.Items.PLANKS)) {
-            // Must be [0,4)
-            if (4 > processState) {
+            // Must be [0,3)
+            if (3 > processState) {
                 frameBlockEntity.insertPlanks(heldStack.split(1));
                 level.setBlock(blockPos, blockState.cycle(FRAME_PROCESSED), 10);
                 level.playSound(null, blockPos, SoundEvents.WOOD_PLACE, SoundSource.BLOCKS, 1.5F,
@@ -117,8 +116,8 @@ public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlo
 
         // Should we do bolt stuff
         if (heldStack.is(FirmacivItems.COPPER_BOLT.get())) {
-            // Must be [4,8)
-            if (4 <= processState && processState < 8) {
+            // Must be [3,7)
+            if (3 <= processState && processState < 7) {
                 frameBlockEntity.insertBolts(heldStack.split(1));
                 level.setBlock(blockPos, blockState.cycle(FRAME_PROCESSED), 10);
                 level.playSound(null, blockPos, SoundEvents.METAL_PLACE, SoundSource.BLOCKS, 1.5F,

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
@@ -27,13 +27,15 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlock {
     public static final IntegerProperty FRAME_PROCESSED = FirmacivBlockStateProperties.FRAME_PROCESSED_7;
 
     public final RegistryWood wood;
 
-    public WoodenBoatFrameBlock(final RegistryWood wood, final BlockState blockState, final Properties properties) {
+    public WoodenBoatFrameBlock(final RegistryWood wood, final Supplier<BlockState> blockState,
+            final Properties properties) {
         super(blockState, properties);
         this.registerDefaultState(
                 this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HALF, Half.BOTTOM)

--- a/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/block/WoodenBoatFrameBlock.java
@@ -33,9 +33,18 @@ public class WoodenBoatFrameBlock extends SquaredAngleBlock implements EntityBlo
 
     public final RegistryWood wood;
 
+    @Deprecated
     public WoodenBoatFrameBlock(final RegistryWood wood, final Supplier<BlockState> blockState,
             final Properties properties) {
         super(blockState, properties);
+        this.registerDefaultState(
+                this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(SHAPE, StairsShape.STRAIGHT)
+                        .setValue(WATERLOGGED, false).setValue(FRAME_PROCESSED, 0));
+        this.wood = wood;
+    }
+
+    public WoodenBoatFrameBlock(final RegistryWood wood, final Properties properties) {
+        super(properties);
         this.registerDefaultState(
                 this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(SHAPE, StairsShape.STRAIGHT)
                         .setValue(WATERLOGGED, false).setValue(FRAME_PROCESSED, 0));

--- a/src/main/java/com/hyperdash/firmaciv/common/blockentity/WatercraftFrameBlockEntity.java
+++ b/src/main/java/com/hyperdash/firmaciv/common/blockentity/WatercraftFrameBlockEntity.java
@@ -1,35 +1,50 @@
 package com.hyperdash.firmaciv.common.blockentity;
 
+import com.hyperdash.firmaciv.common.item.FirmacivItems;
+import com.hyperdash.firmaciv.util.FirmacivTags;
 import net.dries007.tfc.util.Helpers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.items.ItemStackHandler;
 
 public class WatercraftFrameBlockEntity extends BlockEntity {
-    private ItemStack planks = ItemStack.EMPTY;
-    private ItemStack bolts = ItemStack.EMPTY;
+
+    public static final int plankSlot = 0;
+    public static final int boltSlot = 1;
+    /**
+     * ItemHandler to manage our two stacks as it's convenient
+     */
+    private final ItemStackHandler frameContents = new ItemStackHandler(2) {
+        @Override
+        public boolean isItemValid(final int slotIndex, final ItemStack itemStack) {
+            if (plankSlot == slotIndex) {
+                return itemStack.is(FirmacivTags.Items.PLANKS);
+            }
+
+            if (boltSlot == slotIndex) {
+                return itemStack.is(FirmacivItems.COPPER_BOLT.get());
+            }
+
+            return super.isItemValid(slotIndex, itemStack);
+        }
+    };
 
     public WatercraftFrameBlockEntity(final BlockPos blockPos, final BlockState blockState) {
         super(FirmacivBlockEntities.WATERCRAFT_FRAME_BLOCK_ENTITY.get(), blockPos, blockState);
     }
 
-    public void loadAdditional(final CompoundTag compoundTag) {
-        planks = ItemStack.of(compoundTag.getCompound("Planks"));
-        bolts = ItemStack.of(compoundTag.getCompound("Bolts"));
-    }
-
     @Override
     public void saveAdditional(final CompoundTag compoundTag) {
-        compoundTag.put("Planks", planks.serializeNBT());
-        compoundTag.put("Bolts", bolts.serializeNBT());
+        compoundTag.put("Contents", frameContents.serializeNBT());
         super.saveAdditional(compoundTag);
     }
 
     @Override
     public final void load(final CompoundTag compoundTag) {
-        this.loadAdditional(compoundTag);
+        frameContents.deserializeNBT(compoundTag.getCompound("Contents"));
         super.load(compoundTag);
     }
 
@@ -38,43 +53,43 @@ public class WatercraftFrameBlockEntity extends BlockEntity {
      */
     public void ejectContents() {
         assert this.level != null : "Level should not be null";
-        Helpers.spawnItem(this.level, this.worldPosition, planks);
-        Helpers.spawnItem(this.level, this.worldPosition, bolts);
+        for (int slotIndex = 0; slotIndex < frameContents.getSlots(); slotIndex++) {
+            Helpers.spawnItem(this.level, this.worldPosition, frameContents.getStackInSlot(slotIndex));
+        }
     }
 
     /**
      * Adds the passed in stack to our plank total
      *
      * @param itemStack Stack of planks to add
+     * @return Remainder of the inserted stack
      */
-    public void insertPlanks(final ItemStack itemStack) {
-        if (planks.isEmpty()) {
-            planks = itemStack.copy();
-        } else planks.grow(itemStack.getCount());
+    public ItemStack insertPlanks(final ItemStack itemStack) {
+        return frameContents.insertItem(plankSlot, itemStack, false);
     }
 
     /**
      * Adds the passed in stack to our bolts total.
      *
      * @param itemStack Stack of bolts to add
+     * @return Remainder of the inserted stack
      */
-    public void insertBolts(final ItemStack itemStack) {
-        if (bolts.isEmpty()) {
-            bolts = itemStack.copy();
-        } else bolts.grow(itemStack.getCount());
+    @SuppressWarnings("UnusedReturnValue")
+    public ItemStack insertBolts(final ItemStack itemStack) {
+        return frameContents.insertItem(boltSlot, itemStack, false);
     }
 
     /**
      * Extracts planks from the amount we have
      */
     public ItemStack extractPlanks(final int amount) {
-        return planks.split(amount);
+        return frameContents.extractItem(plankSlot, amount, false);
     }
 
     /**
      * Extracts bolts from the amount we have
      */
     public ItemStack extractBolts(final int amount) {
-        return bolts.split(amount);
+        return frameContents.extractItem(boltSlot, amount, false);
     }
 }


### PR DESCRIPTION
- Fixed being able to put any plank into a frame even if it didn't match the type.
- Moved from 8 process states to 7

- Cleaned up SquaredAngleBlock as we don't need to be able to inject a blockstate or block to redirect methods to
- As we no longer need to redirect some methods the constructors have been simplified. SquaredAngleBlock takes only a properties object like most other blocks
- All classes inheriting from SquaredAngleBlock (AngledBoatFrameBlock and WoodenBoatFrameBlock) have had their constructors updated to match
- The Half property was also removed as the block is only in a valid state if it's value is bottom. The related VoxelShape were also removed