### PR TITLE
Fix compass rotation direction

### DIFF
--- a/src/main/java/com/alekiponi/firmaciv/client/FirmacivClientEvents.java
+++ b/src/main/java/com/alekiponi/firmaciv/client/FirmacivClientEvents.java
@@ -94,7 +94,7 @@ public class FirmacivClientEvents {
                                     } else {
                                         rotation = entity.getYRot();
                                     }
-                                    direction = ((Mth.wrapDegrees(rotation) + 180) % 360) / 360;
+                                    direction = ((Mth.wrapDegrees(-rotation) + 180) % 360) / 360;
                                 } else {
                                     direction = Math.random();
                                 }


### PR DESCRIPTION
Addresses #44
Currently the true north compass rotates in the wrong direction when the player rotates. This causes the direction to be wrong at every heading besides 0 and 180.

Sorry about the washed out videos, my recording software is not handling capturing HDR well

Current rotation behavior:

https://github.com/HyperDashPony/FirmaCiv/assets/9094640/37996cf8-81c7-4676-a5b3-9b78e01c45b6

Fixed rotation behavior (always points north):

https://github.com/HyperDashPony/FirmaCiv/assets/9094640/4f45edce-a39e-4d6c-a29d-cf45d9efc52b

